### PR TITLE
fix(package): Make sure the package is public for npm for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "author": "edX",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/edx/gradebook#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@edx/edx-bootstrap": "^0.4.3",
     "@edx/frontend-auth": "^1.0.3",


### PR DESCRIPTION
@reillz10 and @iloveagent57 Please review.
We need this flag to make sure the package is not private for npm so we can publish to it.