### PR TITLE
fix(UI): round numerator of grade ratios.

### DIFF
--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -176,7 +176,7 @@ export default class Gradebook extends React.Component {
     return 'Tracks';
   };
 
-  roundPercentageGrade = percent => parseFloat(percent.toFixed(DECIMAL_PRECISION));
+  roundGrade = percent => parseFloat(percent.toFixed(DECIMAL_PRECISION));
 
   formatter = {
     percent: entries => entries.map((entry) => {
@@ -189,11 +189,11 @@ export default class Gradebook extends React.Component {
               className="btn btn-header link-style"
               onClick={() => this.setNewModalState(entry, subsection)}
             >
-              {this.roundPercentageGrade(subsection.percent * 100)}%
+              {this.roundGrade(subsection.percent * 100)}%
             </button>);
           return acc;
         }, {});
-      const totals = { total: `${this.roundPercentageGrade(entry.percent * 100)}%` };
+      const totals = { total: `${this.roundGrade(entry.percent * 100)}%` };
       return Object.assign(results, assignments, totals);
     }),
 
@@ -207,12 +207,12 @@ export default class Gradebook extends React.Component {
               className="btn btn-header link-style"
               onClick={() => this.setNewModalState(entry, subsection)}
             >
-              {subsection.score_earned}/{subsection.score_possible}
+              {this.roundGrade(subsection.score_earned)}/{this.roundGrade(subsection.score_possible)}
             </button>);
           return acc;
         }, {});
 
-      const totals = { total: `${entry.percent * 100}/100` };
+      const totals = { total: `${this.roundGrade(entry.percent * 100)}/100` };
       return Object.assign(results, assignments, totals);
     }),
   };


### PR DESCRIPTION
When selecting "absolute" as the score view, you can get floats in need of rounding, as depicted in the attached image.  This PR rounds the numerator of the absolute total grade.  It also rounds the numerator and denominator of absolute subsection grades, for consistency.
<img width="1067" alt="screen shot 2018-12-10 at 2 08 07 pm" src="https://user-images.githubusercontent.com/2307986/49754860-397ad000-fc85-11e8-8da3-770c3ace9893.png">
