### PR TITLE
Distinguish unattempted subsections.

### DIFF
--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -39,17 +39,23 @@ export default class Gradebook extends React.Component {
   }
 
   setNewModalState = (userEntry, subsection) => {
+    let adjustedGradePossible = '';
+    let currentGradePossible = '';
+    if (subsection.attempted) {
+      adjustedGradePossible = ` / ${subsection.score_possible}`;
+      currentGradePossible = `/${subsection.score_possible}`;
+    }
     this.setState({
       modalModel: [{
         username: userEntry.username,
-        currentGrade: `${subsection.score_earned}/${subsection.score_possible}`,
+        currentGrade: `${subsection.score_earned}${currentGradePossible}`,
         adjustedGrade: (
           <span>
             <input
               style={{ width: '25px' }}
               type="text"
               onChange={event => this.setState({ updateVal: event.target.value })}
-            /> / {subsection.score_possible}
+            />{adjustedGradePossible}
           </span>
         ),
         assignmentName: `${subsection.subsection_name}`,
@@ -206,16 +212,23 @@ export default class Gradebook extends React.Component {
       const assignments = entry.section_breakdown
         .filter(section => section.is_graded)
         .reduce((acc, subsection) => {
+          const scoreEarned = this.roundGrade(subsection.score_earned);
+          const scorePossible = this.roundGrade(subsection.score_possible);
+          let label = `${scoreEarned}`;
+          if (subsection.attempted) {
+            label = `${scoreEarned}/${scorePossible}`;
+          }
           if (areGradesFrozen) {
-            acc[subsection.label] = `${this.roundGrade(subsection.score_earned)}/${this.roundGrade(subsection.score_possible)}`;
+            acc[subsection.label] = label;
           } else {
             acc[subsection.label] = (
               <button
                 className="btn btn-header link-style"
                 onClick={() => this.setNewModalState(entry, subsection)}
               >
-                {this.roundGrade(subsection.score_earned)}/{this.roundGrade(subsection.score_possible)}
-              </button>);
+                {label}
+              </button>
+            );
           }
           return acc;
         }, {});


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3643

Here's what the whole table looks like (note the "0"s for unattempted subsections):
<img width="1050" alt="screen shot 2018-12-12 at 3 04 50 pm" src="https://user-images.githubusercontent.com/2307986/49895769-5945fb80-fe1f-11e8-96da-dc9444a324e0.png">

And here's the edit modal for an unattempted subsection:
<img width="523" alt="screen shot 2018-12-12 at 3 05 07 pm" src="https://user-images.githubusercontent.com/2307986/49895816-78dd2400-fe1f-11e8-9dff-61169d6b1b72.png">
