### PR TITLE
changed role error message and don't show during loading

### DIFF
--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -252,9 +252,9 @@ export default class Gradebook extends React.Component {
                 The grades for this course are now frozen. Editing of grades is no longer allowed.
               </div>
             }
-            { !this.props.canUserViewGradebook &&
+            { (this.props.canUserViewGradebook === false) &&
               <div className="alert alert-warning" role="alert" >
-                You are not authorized to view the gradebook for this course. If you have a global role, please enroll in this course and try again.
+                You are not authorized to view the gradebook for this course.
               </div>
             }
             <hr />


### PR DESCRIPTION
The second part of the message was never actually true but was left in mistakenly.
Also, I wanted to hide the message while we're loading grades, only show if we for sure can't view gradebook