### PR TITLE
add metadata for openedx releases

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -1,0 +1,8 @@
+# This file describes this Open edX repo, as described in OEP-2:
+# http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
+
+nick: grbk
+oeps: {}
+owner: edx/educator-neem
+openedx-release: {ref: master}
+track-pulls: true


### PR DESCRIPTION
Followup to [EDUCATOR-3853](https://openedx.atlassian.net/browse/EDUCATOR-3853)

@nedbat mentioned we need this file for openedx since gradebook is a main project installed within devstack.