### PR TITLE
fix(bug): make sure gradebook rounding handle null input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10469,14 +10469,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10496,8 +10494,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -10645,7 +10642,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -176,7 +176,7 @@ export default class Gradebook extends React.Component {
     return 'Tracks';
   };
 
-  roundGrade = percent => parseFloat(percent.toFixed(DECIMAL_PRECISION));
+  roundGrade = percent => parseFloat((percent || 0).toFixed(DECIMAL_PRECISION));
 
   formatter = {
     percent: (entries, areGradesFrozen) => entries.map((entry) => {


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3925

This is to fix the problem in stage
If you go to https://gradebook.stage.edx.org/course-v1:MITx+6.002x+MITx_2012_Alumni and switch to the "Absolute view", you will see broken gradebook. This fixes that partially. We also want an update on the edx-platform API