### PR TITLE
Change repo owner from edx/educator-neem to schenedx

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -3,6 +3,5 @@
 
 nick: grbk
 oeps: {}
-owner: edx/educator-neem
+owner: schenedx
 openedx-release: {ref: master}
-track-pulls: true


### PR DESCRIPTION
Per recent change to OEP-2 https://github.com/edx/open-edx-proposals/pull/112/files

Also, remove track-pulls, which OEP-2 now says is an obsolete property.