### PR TITLE
fix forward for including intlprovider

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "query-string": "^5.1.1",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
+    "react-intl": "^2.9.0",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import SiteFooter from '@edx/frontend-component-footer';
+import { IntlProvider } from 'react-intl';
 
 import {
   faFacebookSquare,
@@ -55,39 +56,41 @@ const socialLinks = [
 ];
 
 const App = () => (
-  <Provider store={store}>
-    <Router>
-      <div>
-        <Header />
-        <main>
-          <Switch>
-            <Route exact path="/:courseId" component={GradebookPage} />
-          </Switch>
-        </main>
-        <SiteFooter
-          siteName={process.env.SITE_NAME}
-          siteLogo={FooterLogo}
-          marketingSiteBaseUrl={process.env.MARKETING_SITE_BASE_URL}
-          supportUrl={process.env.SUPPORT_URL}
-          contactUrl={process.env.CONTACT_URL}
-          openSourceUrl={process.env.OPEN_SOURCE_URL}
-          termsOfServiceUrl={process.env.TERMS_OF_SERVICE_URL}
-          privacyPolicyUrl={process.env.PRIVACY_POLICY_URL}
-          appleAppStoreUrl={process.env.APPLE_APP_STORE_URL}
-          googlePlayUrl={process.env.GOOGLE_PLAY_URL}
-          socialLinks={socialLinks}
-          enterpriseMarketingLink={{
-            url: process.env.ENTERPRISE_MARKETING_URL,
-            queryParams: {
-              utm_source: process.env.ENTERPRISE_MARKETING_UTM_SOURCE,
-              utm_campaign: process.env.ENTERPRISE_MARKETING_UTM_CAMPAIGN,
-              utm_medium: process.env.ENTERPRISE_MARKETING_FOOTER_UTM_MEDIUM,
-            },
-          }}
-        />
-      </div>
-    </Router>
-  </Provider>
+  <IntlProvider>
+    <Provider store={store}>
+      <Router>
+        <div>
+          <Header />
+          <main>
+            <Switch>
+              <Route exact path="/:courseId" component={GradebookPage} />
+            </Switch>
+          </main>
+          <SiteFooter
+            siteName={process.env.SITE_NAME}
+            siteLogo={FooterLogo}
+            marketingSiteBaseUrl={process.env.MARKETING_SITE_BASE_URL}
+            supportUrl={process.env.SUPPORT_URL}
+            contactUrl={process.env.CONTACT_URL}
+            openSourceUrl={process.env.OPEN_SOURCE_URL}
+            termsOfServiceUrl={process.env.TERMS_OF_SERVICE_URL}
+            privacyPolicyUrl={process.env.PRIVACY_POLICY_URL}
+            appleAppStoreUrl={process.env.APPLE_APP_STORE_URL}
+            googlePlayUrl={process.env.GOOGLE_PLAY_URL}
+            socialLinks={socialLinks}
+            enterpriseMarketingLink={{
+              url: process.env.ENTERPRISE_MARKETING_URL,
+              queryParams: {
+                utm_source: process.env.ENTERPRISE_MARKETING_UTM_SOURCE,
+                utm_campaign: process.env.ENTERPRISE_MARKETING_UTM_CAMPAIGN,
+                utm_medium: process.env.ENTERPRISE_MARKETING_FOOTER_UTM_MEDIUM,
+              },
+            }}
+          />
+        </div>
+      </Router>
+    </Provider>
+  </IntlProvider>
 );
 
 apiClient.ensurePublicOrAuthenticationAndCookies(


### PR DESCRIPTION
Note: This is a fix-forward PR.

The `@edx/frontend-component-footer` package now requires the app to be wrapped in the `IntlProvider` component from `react-intl`.

Including the `IntlProvider` component should resolve these errors.